### PR TITLE
Download page: Because of the compatibility problems with versions below win10, we need to add a system tip

### DIFF
--- a/packages/neuron/package.json
+++ b/packages/neuron/package.json
@@ -54,7 +54,6 @@
     "@types/node": "^20.2.5",
     "@types/react": "^18.2.8",
     "@types/react-dom": "^18.2.4",
-    "@types/ua-parser-js": "^0.7.36",
     "@typescript-eslint/eslint-plugin": "^5.59.8",
     "@typescript-eslint/parser": "^5.59.8",
     "eslint": "^8.41.0",

--- a/packages/neuron/src/pages/download/Assets/index.module.scss
+++ b/packages/neuron/src/pages/download/Assets/index.module.scss
@@ -35,6 +35,7 @@
         display: flex;
         gap: 4px;
         align-items: center;
+        white-space: nowrap;
       }
 
       &.checksum {

--- a/packages/neuron/src/pages/download/Assets/index.tsx
+++ b/packages/neuron/src/pages/download/Assets/index.tsx
@@ -61,7 +61,16 @@ export const Assets$Desktop: FC<AssetsProps> = ({ assets, ...tableProps }) => {
                 {asset.os.toLowerCase() === 'windows' && <IconWindows />}
                 {asset.os.toLowerCase() === 'macos' && <IconMacOS />}
                 {asset.os.toLowerCase() === 'linux' && <IconLinux />}
-                {asset.os}
+                {asset.os.toLowerCase() === 'windows' ? (
+                  <>
+                    Windows 10+
+                    <Tooltip content="System versions that are no longer officially supported are not recommended and may have compatibility or security issues.">
+                      <IconTips />
+                    </Tooltip>
+                  </>
+                ) : (
+                  asset.os
+                )}
               </div>
             </td>
             <td>{asset.arch}</td>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2304,7 +2304,6 @@ __metadata:
     "@types/node": ^20.2.5
     "@types/react": ^18.2.8
     "@types/react-dom": ^18.2.4
-    "@types/ua-parser-js": ^0.7.36
     "@typescript-eslint/eslint-plugin": ^5.59.8
     "@typescript-eslint/parser": ^5.59.8
     "@vercel/kv": ^0.2.3
@@ -3947,13 +3946,6 @@ __metadata:
   version: 1.2.0
   resolution: "@types/symlink-or-copy@npm:1.2.0"
   checksum: 18fb73094b2cf6c84544939bd6344d7a8cd1ccf8496a1cfb1320f38491c8dfbea3248bb6e91495322a51a493e04a767582a214d5261f5c5b007aa6ef65fc8b50
-  languageName: node
-  linkType: hard
-
-"@types/ua-parser-js@npm:^0.7.36":
-  version: 0.7.36
-  resolution: "@types/ua-parser-js@npm:0.7.36"
-  checksum: 8c24d4dc12ed1b8b98195838093391c358c81bf75e9cae0ecec8f7824b441e069daaa17b974a3e257172caddb671439f0c0b44bf43bfcf409b7a574a25aab948
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The current implementation is hard-coded and will display "Windows 10+" and provide suggestions whenever the OS is Windows.

Refs: https://github.com/Magickbase/neuron-public-issues/issues/328